### PR TITLE
Run ESLint on GitHub Actions as CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,13 @@
+name: vite-blog-ci
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: '16'
+        check-latest: true
+    - run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 dist
 dist-ssr
 *.local
+
+.eslintcache

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+test: deps eslint
+
+eslint:
+	yarn eslint --cache src
+
+deps:
+	yarn install


### PR DESCRIPTION
Run ESLint on GitHub Actions continuously.

Declare tasks on Makefile instead of write it to YAML directly, thus we can run the task manually.