### PR TITLE
Update HTML title by the article's one

### DIFF
--- a/src/pages/PostDetail.tsx
+++ b/src/pages/PostDetail.tsx
@@ -50,6 +50,15 @@ export const PostDetail: React.VFC = () => {
                 setPost(false);
             });
     }, [path]);
+    useEffect(() => {
+        const originalTitle = document.title;
+        if (post !== null && post !== false) {
+            document.title = post.meta.title;
+        }
+        return () => {
+            document.title = originalTitle;
+        };
+    }, [post]);
     if (post === null) {
         return null;
     }


### PR DESCRIPTION
Update title element on HTML by its title when the visitor open any article page.

The title should restore when they leave an article page.