### PR TITLE
Declare dev and build/preview as make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+dev:
+	yarn dev
+
 test: eslint typecheck prettier
 
 eslint:
@@ -17,3 +20,7 @@ prettier/write:
 
 deploy:
 	firebase deploy --only hosting
+
+build:
+	yarn build
+	yarn preview


### PR DESCRIPTION
I consider Makefile as a common operation interface.

It doesn't matter if the concrete implementation can be found in package.json.